### PR TITLE
FIX: Fixed the raise of an exception during SIP register.

### DIFF
--- a/snl/UA.py
+++ b/snl/UA.py
@@ -18,8 +18,6 @@ from . import Media
 from . import Timer
 from . import Dialog
 from . import Security
-from . import Transport
-from . import Utils
 
 try:
     import card.USIM as USIM
@@ -241,7 +239,7 @@ class RegistrationManager:
                 if expiresheader:
                     gotexpires = expiresheader.delta
                 contactheader = event.header('Contact')
-                if contactheader:
+                if contactheader and contactheader.params.get('expires'):
                     gotexpires = contactheader.params.get('expires')
                 if gotexpires > 0:
                     self.registered = True


### PR DESCRIPTION
During the register of the UA against a Registrar server if _expires_ paramater was not present in the _Contact_ header an exception was raised. Logs:

17:33:48,215 ##########################< SIPandLove >##########################
17:33:48,611 WARNING  Security cannot import Milenage (No module named 'Crypto'). AKA authentication is not possible
17:33:48,612 WARNING  Security scapy is not pre-loaded
17:33:48,615 WARNING  Security cannot run xfrm command (try as root)
17:33:48,645 WARNING  Transport Cannot open raw socket for ICMP
17:33:48,684 WARNING  UA cannot import card (No module named 'card'). SIM-AKA authentication is not possible
17:33:48,692 INFO     Transport 192.168.1.136:5061 starting process 2506449
17:33:48,698 INFO     Transport UDP listening on 192.168.1.136:5061 (fd=19)
17:33:48,699 INFO     Transport TCP listening on 192.168.1.136:5061 (fd=20)
17:33:48,737 INFO     UA sip:iker@192.168.1.136:5061 registering for 3600s
17:33:48,828 INFO     Transport 192.168.1.136:5061 --UDP-> 192.168.1.136:5060 (fd=19)
   REGISTER sip:myvoipapp.com SIP/2.0
   Via: SIP/2.0/UDP 192.168.1.136:5061;branch=z9hG4bK_SIPandLove_lyqUjE
   From: <sip:iker@myvoipapp.com>;tag=SIPandLove_mAcajO
   To: sip:iker@myvoipapp.com
   Contact: sip:iker@192.168.1.136:5061
   Expires: 3600
   Call-ID: SNL_flashy_subcompact_1
   CSeq: 17411 REGISTER
   Max-Forwards: 70
   Allow: ACK, BYE, CANCEL, OPTIONS, NOTIFY, INVITE
   
17:33:48,883 INFO     Transport 192.168.1.136:5061 <-UDP-- 192.168.1.136:5060 (fd=19)
   SIP/2.0 401 Unauthorized
   Via: SIP/2.0/UDP 192.168.1.136:5061;branch=z9hG4bK_SIPandLove_lyqUjE
   From: <sip:iker@myvoipapp.com>;tag=SIPandLove_mAcajO
   To: <sip:iker@myvoipapp.com>;tag=2869d78551625ad3
   Call-ID: SNL_flashy_subcompact_1
   CSeq: 17411 REGISTER
   WWW-Authenticate: Digest realm="myvoipapp.com",nonce="436F75FF4D60FF7C411E2D5F207F96F3",algorithm=MD5,stale=true
   Allow: ACK,BYE,CANCEL,INFO,INVITE,MESSAGE,NOTIFY,OPTIONS,PRACK,REFER,REGISTER,SUBSCRIBE
   Content-Length: 0
   
17:33:48,883 INFO     UA sip:iker@192.168.1.136:5061 401 retrying REGISTER with authentication
17:33:48,885 INFO     Transport 192.168.1.136:5061 --UDP-> 192.168.1.136:5060 (fd=19)
   REGISTER sip:myvoipapp.com SIP/2.0
   Via: SIP/2.0/UDP 192.168.1.136:5061;branch=z9hG4bK_SIPandLove_qidykI
   From: <sip:iker@myvoipapp.com>;tag=SIPandLove_mAcajO
   To: sip:iker@myvoipapp.com
   Contact: sip:iker@192.168.1.136:5061
   Expires: 3600
   Call-ID: SNL_flashy_subcompact_1
   CSeq: 17412 REGISTER
   Max-Forwards: 70
   Authorization: Digest realm="myvoipapp.com",uri="sip:myvoipapp.com",username="iker@myvoipapp.com",nonce="436F75FF4D60FF7C411E2D5F207F96F3",algorithm=MD5,response="df51159f42ded03f7801f4acca6e6da6"
   Allow: ACK, BYE, CANCEL, OPTIONS, NOTIFY, INVITE
   
17:33:48,936 INFO     Transport 192.168.1.136:5061 <-UDP-- 192.168.1.136:5060 (fd=19)
   SIP/2.0 200 OK
   Via: SIP/2.0/UDP 192.168.1.136:5061;branch=z9hG4bK_SIPandLove_qidykI
   From: <sip:iker@myvoipapp.com>;tag=SIPandLove_mAcajO
   To: <sip:iker@myvoipapp.com>;tag=4138b7343ee61841
   Contact: iker <sip:iker@192.168.1.136:5061>
   Expires: 120
   Call-ID: SNL_flashy_subcompact_1
   CSeq: 17412 REGISTER
   Server: miniSIPServer V39 (20 clients) build 20220614
   Allow: ACK,BYE,CANCEL,INFO,INVITE,MESSAGE,NOTIFY,OPTIONS,PRACK,REFER,REGISTER,SUBSCRIBE
   Content-Length: 0
   
Traceback (most recent call last):
  File "test/test.py", line 15, in <module>
    main()
  File "test/test.py", line 4, in main
    phoneA = snl.SIPPhoneClass()(
  File "/home/nemergent/PycharmProjects/SIPandLove/snl/UA.py", line 555, in __init__
    super().__init__(**kwargs)
  File "/home/nemergent/PycharmProjects/SIPandLove/snl/UA.py", line 364, in __init__
    super().__init__(**kwargs)
  File "/home/nemergent/PycharmProjects/SIPandLove/snl/UA.py", line 283, in __init__
    super().__init__(**kwargs)
  File "/home/nemergent/PycharmProjects/SIPandLove/snl/UA.py", line 203, in __init__
    self.register()
  File "/home/nemergent/PycharmProjects/SIPandLove/snl/UA.py", line 212, in register
    return self._register(expires, *headers)
  File "/home/nemergent/PycharmProjects/SIPandLove/snl/UA.py", line 344, in _register
    registered = super()._register(expires, *headers)
  File "/home/nemergent/PycharmProjects/SIPandLove/snl/UA.py", line 244, in _register
    if gotexpires > 0:
TypeError: '>' not supported between instances of 'NoneType' and 'int'
17:33:48,938 INFO     Transport 192.168.1.136:5061 process 2506449 stopped